### PR TITLE
force web service url for objectpicker to a select value list

### DIFF
--- a/assets/js/editionPageModule/models/Fields.js
+++ b/assets/js/editionPageModule/models/Fields.js
@@ -925,7 +925,8 @@ define([
                     validators: ['required']
                 },
                 wsUrl: {
-                    type: 'Text',
+                    type: 'Select',
+                    options: ["autocomplete/Individual", "autocomplete/monitoredSites", "autocomplete/Sensor"],
                     template: fieldTemplate,
                     title: translater.getValueFromKey('schema.wsUrl'),
                     validators: ['required']


### PR DESCRIPTION
As the title says 
Objectpicker displayed an input for manually set the web services url

We change the input to a select 
and the value list is hard coded in options value 

will need a refact to bind all inputs (name , webserviceurl , object)